### PR TITLE
fix(accounts): Only re-send verification to unverified accounts

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -339,6 +339,9 @@ class AppSettings(object):
                 ret = []
         return ret
 
+    @property
+    def EMAIL_RESEND_VERIFICATION_UNVERIFIED(self):
+        return self._setting("EMAIL_RESEND_VERIFICATION_UNVERIFIED", True)
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -462,6 +462,9 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
 
     def _action_send(self, request, *args, **kwargs):
         email = request.POST["email"]
+        if EmailAddress.objects.filter(email=email, verified=True).exists():
+            messages.error(self.request, "A link to activate your account has been emailed to the address provided")
+            return HttpResponseRedirect(self.request.path_info)
         try:
             email_address = EmailAddress.objects.get(
                 user=request.user,

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -463,7 +463,9 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
     def _action_send(self, request, *args, **kwargs):
         email = request.POST["email"]
         if EmailAddress.objects.filter(email=email, verified=True).exists():
-            messages.error(self.request, "A link to activate your account has been emailed to the address provided")
+            adapter = get_adapter(request)
+            template = 'account/messages/resend_verified_error.txt'
+            adapter.add_message(request,messages.INFO,template,{'email': email})
             return HttpResponseRedirect(self.request.path_info)
         try:
             email_address = EmailAddress.objects.get(

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -462,7 +462,7 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
 
     def _action_send(self, request, *args, **kwargs):
         email = request.POST["email"]
-        if EmailAddress.objects.filter(email=email, verified=True).exists():
+        if EmailAddress.objects.filter(email=email, verified=True).exists() and app_settings.EMAIL_RESEND_VERIFICATION_UNVERIFIED is True:
             adapter = get_adapter(request)
             template = 'account/messages/resend_verified_error.txt'
             adapter.add_message(request,messages.INFO,template,{'email': email})

--- a/allauth/templates/account/messages/resend_verified_error.txt
+++ b/allauth/templates/account/messages/resend_verified_error.txt
@@ -1,1 +1,2 @@
-A link to activate your account has been emailed to the address provided
+{% load i18n %}
+{% blocktrans %}A link to activate your account has been emailed to the address provided{% endblocktrans %}

--- a/allauth/templates/account/messages/resend_verified_error.txt
+++ b/allauth/templates/account/messages/resend_verified_error.txt
@@ -1,0 +1,1 @@
+A link to activate your account has been emailed to the address provided


### PR DESCRIPTION


A user is able to click on the re-send verification button in /accounts/email/ which will re-send another verification email again to the already verified email address if it was previously verified. This will check to see if that email address has already been verified and prevent the re-send verification email from sending out again to those verified users. 

I decided to use "A link to activate your account has been emailed to the address provided" as the error message as opposed to "This e-mail has already been verified" to stay within OWASP guidelines - see the email privacy leak issue (if we decide on using this OWASP error messaging throughout allauth). 

But I suppose changing the error message to something else would be okay for this particular case (in other places though OWASP wording would be better). 

If you want to allow users to create their own custom message, comment out messages.error and use:

```
            adapter = get_adapter(request)
            template = 'account/messages/resend_verified_error.txt'
            adapter.add_message(request,messages.INFO,template,{'email': email})
```

https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html